### PR TITLE
Add Volcano Integration custom component to HACS

### DIFF
--- a/integration
+++ b/integration
@@ -1312,6 +1312,7 @@
   "sugoi-wada/acer-air-monitor-2018",
   "superrob/genvexconnect",
   "suppqt/hass_mars_hydro",
+  "svasek/homeassistant-vistapool-modbus",
   "swartjean/ha-eskom-loadshedding",
   "swartjean/ha-seedboxes-cc",
   "swingerman/ha-dual-smart-thermostat",

--- a/integration
+++ b/integration
@@ -1495,6 +1495,7 @@
   "zeronounours/HA-custom-component-energy-meter",
   "zhbjsh/homeassistant-ssh",
   "zigul/HomeAssistant-CEZdistribuce",
+  "zollak/homeassistant-syslog-receiver",
   "ZsBT/hass-w1000-portal",
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Chuffnugget/volcano_integration/releases/tag/v3.1.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/Chuffnugget/volcano_integration/actions/runs/15524893879>
Link to successful hassfest action (if integration): <https://github.com/Chuffnugget/volcano_integration/actions/runs/15536919929>

